### PR TITLE
Drop the docs from the CST/Cursor generification

### DIFF
--- a/documentation/public/user-guide/concepts.md
+++ b/documentation/public/user-guide/concepts.md
@@ -25,8 +25,7 @@ Slang is capable of parsing the source code into a Concrete Syntax Tree (CST; al
 which is a tree structure of the program that also includes things like punctuation or whitespace.
 
 This is done by using the (standard) approach of lexical analysis followed by syntax analysis.
-The source text as a sequence of characters is recognized into a sequence of
-tokens (lexical analysis), which then in turn is _parsed_ into the CST.
+The source text as a sequence of characters is recognized into a sequence of tokens (lexical analysis), which then in turn is _parsed_ into the CST.
 
 The resulting CST is a regular tree data structure that you can visit.
 The tree nodes are represented by the `Node` structure, which can be one of two kinds:
@@ -39,9 +38,8 @@ The tree nodes are represented by the `Node` structure, which can be one of two 
 For many code analysis tasks, it is useful to traverse the parse tree and visit each node.
 The `Cursor` object allows callers to traverse the parse tree in an efficient pre-order manner.
 
-It provides several `goTo*()` navigation functions, each returning `true` if the
-cursor was successfully moved, and `false` otherwise. There are three main ways
-to do it:
+It provides several `goTo*()` navigation functions, each returning `true` if the cursor was successfully moved, and `false` otherwise.
+There are three main ways to do it:
 
 -   According to the DFS order, i.e. `goToNext()` and `goToPrevious()`,
 -   According to the relationship between the current node and the next node, i.e. `goToParent()`, `goToFirstChild()`, `goToNextNonDescendent()`
@@ -50,28 +48,6 @@ to do it:
 As such, the cursor is stateful and keeps track of the path it has taken through the CST.
 It starts at the root it was created at and is completed when it reaches its root when navigating forward.
 
-## CST Queries
-
-The `Cursor` API is a low-level API that allows you to traverse the CST in a
-procedural manner. However, it is often more convenient to use the declarative
-`Query` API. Queries allow you to express your intent more concisely, and also
-allows you to reuse the same query in multiple places. Queries can largely
-replace the need for both internal (cursor), and external (visitor) iterator
-patterns.
-
-The [query language](./query-language.md) is based on pattern matching, and the
-execution semantics are closer to unification than to regular expression
-matching i.e. a query returns all possible matches, not just the
-longest/shortest/first/last match. There is no concept of a 'greedy' operator
-for example.
-
-Query execution is based on `Cursor`s, and the resulting matches and unification
-bindings are returned as `Cursor`s as well. This allows you to mix and match
-manual traversal, cursors, and queries.
-
-Multiple queries can be executed in a batch, and efficiently traverse the tree
-looking for matches. This mode of operation can replace all visitor patterns.
-
 ## Abstract Syntax Tree (AST)
 
 AST types are a set of abstractions that provide a typed view of the untyped CST nodes.
@@ -79,6 +55,3 @@ You can convert any untyped CST node to its corresponding AST type using their c
 
 There is a corresponding type for each `RuleKind` (non-terminal) in the language. AST types are immutable.
 Additionally, their fields are constructed lazily as they are accessed for the first time.
-
-AST nodes can maintain a reference to the CST node they were constructed from,
-and can be used to navigate to the corresponding CST node.

--- a/documentation/public/user-guide/npm-package/NAV.md
+++ b/documentation/public/user-guide/npm-package/NAV.md
@@ -1,5 +1,4 @@
 -   [Installation](./installation.md)
 -   [Using the Parser](./using-the-parser.md)
 -   [Using the Cursor](./using-the-cursor.md)
--   [Using Queries](./using-queries.md)
 -   [Using the AST](./using-the-ast.md)

--- a/documentation/public/user-guide/rust-crate/NAV.md
+++ b/documentation/public/user-guide/rust-crate/NAV.md
@@ -2,4 +2,3 @@
 -   [Using the CLI](./using-the-cli.md)
 -   [Using the Parser](./using-the-parser.md)
 -   [Using the Cursor](./using-the-cursor.md)
--   [Using Queries](./using-queries.md)


### PR DESCRIPTION
It's already added in main.